### PR TITLE
Fix footer email link

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -21,7 +21,7 @@
           <path d="M184 213A140 140 0 0 0 44 73 V 38a175 175 0 0 1 175 175z" fill="currentColor"></path>
         </svg>
       </a>
-      <a href="{{ config.extra.email }}" class="no-border">
+      <a href="mailto:{{ config.extra.email }}" class="no-border">
         <svg id="mail" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="16" height="16" fill="currentcolor" class="social-icon-wide">
           <path d="M0 6 L16 16 L32 6 z M0 9 L0 26 L32 26 L32 9 L16 19 z"></path>
         </svg>


### PR DESCRIPTION
Without the `mailto:` scheme the email address is interpreted as a relative URL and links to a 404 page.